### PR TITLE
was getting 404 error with old station link

### DIFF
--- a/pycitibike/__init__.py
+++ b/pycitibike/__init__.py
@@ -16,7 +16,7 @@ class Citibike(object):
         :param kwargs: a dict of key values for the API.
             I'm actually not fully sure what this supports yet
         """
-        return self._get('data2/stations', kwargs)
+        return self._get('data2/stations.php', kwargs)
 
     def helmets(self, **kwargs):
         """


### PR DESCRIPTION
Was getting 404 on client.stations() and a quick google search and first hit returned this path instead. Updated and now works for me.

https://groups.google.com/forum/#!topic/artsec/NionyixpxqA

Seems to be same data as this link http://citibikenyc.com/stations/json
